### PR TITLE
Initial implementation of stand-alone Correlation Vector

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="System.Diagnostics.DiagnosticSource.cs" />
     <Compile Include="System.Diagnostics.DiagnosticSourceCorrelationVector.cs" />
+    <Compile Include="System.Diagnostics.DiagnosticSourceCorrelationVectorResetResult.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netstandard1.1'">
     <Compile Include="System.Diagnostics.DiagnosticSourceActivity.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{3DF9A5D5-3D4B-4378-9B55-CFA6AC0114D9}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'netfx'">
-     <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS</DefineConstants>
+    <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-Release|AnyCPU'" />
@@ -19,6 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Diagnostics.DiagnosticSource.cs" />
+    <Compile Include="System.Diagnostics.DiagnosticSourceCorrelationVector.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netstandard1.1'">
     <Compile Include="System.Diagnostics.DiagnosticSourceActivity.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Diagnostics
+{
+    public partial class CorrelationVector
+    {
+        public CorrelationVector() { }
+        public string Value { get { throw null; } }
+        public string Increment() { throw null; }
+        public static CorrelationVector Extend( string correlationVector ) { throw null; }
+        public static CorrelationVector Extend( string correlationVector, string spanId ) { throw null; }
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics
     public partial class CorrelationVector
     {
         public CorrelationVector() { }
-        public string PreviousBase { get { throw null; } }
+        public string PreviousValue { get { throw null; } }
         public string Value { get { throw null; } }
         public bool Equals(CorrelationVector correlationVector) { throw null; }
         public string Increment() { throw null; }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
@@ -10,11 +10,9 @@ namespace System.Diagnostics
     public partial class CorrelationVector
     {
         public CorrelationVector() { }
+        public string PreviousBase { get { throw null; } }
         public string Value { get { throw null; } }
         public string Increment() { throw null; }
         public static CorrelationVector Extend(string correlationVector) { throw null; }
-        public static CorrelationVector Extend(string correlationVector, string spanId) { throw null; }
-        public static CorrelationVector Spin(string correlationVector) { throw null; }
-        public static CorrelationVector Spin(string correlationVector, string spanId) { throw null; }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
@@ -12,7 +12,9 @@ namespace System.Diagnostics
         public CorrelationVector() { }
         public string PreviousBase { get { throw null; } }
         public string Value { get { throw null; } }
+        public bool Equals(CorrelationVector correlationVector) { throw null; }
         public string Increment() { throw null; }
         public static CorrelationVector Extend(string correlationVector) { throw null; }
+        public static CorrelationVector Spin(string correlationVector) { throw null; }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
@@ -12,7 +12,9 @@ namespace System.Diagnostics
         public CorrelationVector() { }
         public string Value { get { throw null; } }
         public string Increment() { throw null; }
-        public static CorrelationVector Extend( string correlationVector ) { throw null; }
-        public static CorrelationVector Extend( string correlationVector, string spanId ) { throw null; }
+        public static CorrelationVector Extend(string correlationVector) { throw null; }
+        public static CorrelationVector Extend(string correlationVector, string spanId) { throw null; }
+        public static CorrelationVector Spin(string correlationVector) { throw null; }
+        public static CorrelationVector Spin(string correlationVector, string spanId) { throw null; }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVector.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics
     public partial class CorrelationVector
     {
         public CorrelationVector() { }
-        public string PreviousValue { get { throw null; } }
+        public CorrelationVectorResetResult ResetResult { get { throw null; } }
         public string Value { get { throw null; } }
         public bool Equals(CorrelationVector correlationVector) { throw null; }
         public string Increment() { throw null; }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVectorResetResult.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceCorrelationVectorResetResult.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Diagnostics
+{
+    public partial class CorrelationVectorResetResult
+    {
+        public string BaseVector { get { throw null; } set { throw null; } }
+        public string ResetExtension { get { throw null; } set { throw null; } }
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -36,6 +36,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Diagnostics\CorrelationVector.cs" />
+    <Compile Include="System\Diagnostics\CorrelationVectorResetResult.cs" />
     <Compile Include="System\Diagnostics\DiagnosticSource.cs" />
     <Compile Include="System\Diagnostics\DiagnosticListener.cs" />
     <Compile Include="System\Diagnostics\DiagnosticSourceEventSource.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -35,6 +35,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="System\Diagnostics\CorrelationVector.cs" />
     <Compile Include="System\Diagnostics\DiagnosticSource.cs" />
     <Compile Include="System\Diagnostics\DiagnosticListener.cs" />
     <Compile Include="System\Diagnostics\DiagnosticSourceEventSource.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVector.cs
@@ -155,8 +155,10 @@ namespace System.Diagnostics
             ulong spinElement = GetTimeSortedRandomLong();
 
             // 3 accounts for the "_" before the spin element and the
-            // ".0" at the end of the new CorrelationVector
-            int size = correlationVector.Length + 3 + (int)Math.Log(spinElement, 16) + 1;
+            // ".0" at the end of the new CorrelationVector. Use the
+            // max length of a long represented in hex, as that is worst-
+            // case for the spin element.
+            int size = correlationVector.Length + 3 + (int)Math.Log(ulong.MaxValue, 16) + 1;
 
             if (size > CorrelationVector.MaxVectorLength)
             {
@@ -205,8 +207,11 @@ namespace System.Diagnostics
             byte[] entropy = new byte[4];
             randomGenerator.NextBytes(entropy);
 
+            // spinElement will increment every ~6.5 milliseconds
             ulong spinElement = (ulong)(DateTime.UtcNow.Ticks >> 16);
 
+            // spinElement will form the most significant 4-byte section and
+            // entropy will form the least significant 4-byte section
             for (int i = 0; i < 4; i++)
             {
                 spinElement = (spinElement << 8) | Convert.ToUInt64(entropy[i]);

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVector.cs
@@ -1,0 +1,154 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// This class represents a lightweight vector for identifying and measuring
+    /// causality.
+    /// </summary>
+    public class CorrelationVector
+    {
+        private const byte BaseLength = 22;
+        private const byte MaxVectorLength = 127;
+
+        private string baseVector = null;
+        private int extension = 0;
+        private object resetLock = new object();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CorrelationVector"/> class.
+        /// </summary>
+        public CorrelationVector()
+        {
+            this.baseVector = CorrelationVector.GetBaseFromGuid( Guid.NewGuid() );
+        }
+
+        /// <summary>
+        /// Gets the value of the correlation vector as a string.
+        /// </summary>
+        public string Value
+        {
+            get
+            {
+                return string.Concat( this.baseVector, ".", this.extension );
+            }
+        }
+
+        /// <summary>
+        /// Increments the current extension by one. Do this before passing the value to an
+        /// outbound message header.
+        /// </summary>
+        /// <returns>
+        /// The new value as a string that you can add to the outbound message header.
+        /// </returns>
+        public string Increment()
+        {
+            int snapshot = 0;
+            int next = 0;
+            do
+            {
+                snapshot = this.extension;
+                if ( snapshot == int.MaxValue )
+                {
+                    return this.Value;
+                }
+                next = snapshot + 1;
+                int size = baseVector.Length + 1 + (int)Math.Log10( next ) + 1;
+                if ( size > CorrelationVector.MaxVectorLength )
+                {
+                    // Perform a reset
+                    lock ( resetLock )
+                    {
+                        // Check size again in case another thread did the reset
+                        size = baseVector.Length + 1 + (int)Math.Log10( next ) + 1;
+                        if ( size > CorrelationVector.MaxVectorLength )
+                        {
+                            this.baseVector = string.Concat( "#", CorrelationVector.GetBaseFromGuid( Guid.NewGuid() ) );
+                        }
+                    }
+                }
+            }
+            while ( snapshot != Interlocked.CompareExchange( ref this.extension, next, snapshot ) );
+
+            return string.Concat( this.baseVector, ".", next );
+        }
+
+        /// <summary>
+        /// Creates a new correlation vector by extending an existing value. This should be
+        /// done at the entry point of an operation.
+        /// </summary>
+        /// <param name="correlationVector">
+        /// Taken from the message header.
+        /// </param>
+        /// <returns>A new correlation vector extended from the current vector.</returns>
+        public static CorrelationVector Extend( string correlationVector )
+        {
+            // 2 accounts for the ".0" at the end of the new CorrelationVector
+            int size = correlationVector.Length + 2;
+
+            if ( size > CorrelationVector.MaxVectorLength )
+            {
+                return new CorrelationVector()
+                {
+                    baseVector = string.Concat( "#", CorrelationVector.GetBaseFromGuid( Guid.NewGuid() ) ),
+                    extension = 0
+                };
+            }
+
+            return new CorrelationVector()
+            {
+                baseVector = correlationVector,
+                extension = 0
+            };
+        }
+
+        /// <summary>
+        /// Creates a new correlation vector by extending an existing value. This should be
+        /// done at the entry point of an operation.
+        /// </summary>
+        /// <param name="correlationVector">
+        /// Taken from the message header.
+        /// </param>
+        /// <param name="spanId">
+        /// ID of the Span.
+        /// </param>
+        /// <returns>A new correlation vector extended from the current vector.</returns>
+        public static CorrelationVector Extend( string correlationVector, string spanId )
+        {
+            // 3 accounts for the dash '-' before spanId and ".0" at the end of the
+            // new CorrelationVector
+            int size = correlationVector.Length + spanId.Length + 3;
+
+            if ( size > CorrelationVector.MaxVectorLength )
+            {
+                return new CorrelationVector()
+                {
+                    baseVector = string.Concat(
+                        "#",
+                        CorrelationVector.GetBaseFromGuid( Guid.NewGuid() ),
+                        "-",
+                        spanId ),
+                    extension = 0
+                };
+            }
+
+            return new CorrelationVector()
+            {
+                baseVector = string.Concat( correlationVector, "-", spanId ),
+                extension = 0
+            };
+        }
+
+        private static string GetBaseFromGuid( Guid guid )
+        {
+            byte[] bytes = guid.ToByteArray();
+
+            // Removes the base64 padding
+            return Convert.ToBase64String( bytes ).Substring( 0, CorrelationVector.BaseLength );
+        }
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVector.cs
@@ -32,12 +32,13 @@ namespace System.Diagnostics
         }
 
         /// <summary>
-        /// Gets the value of the Vector Base prior to a reset being performed.
+        /// Gets the previous value of the Vector Base prior to a reset having been performed.
+        /// Value will be null if reset has not yet been performed.
         /// </summary>
         public string PreviousBase { get; private set; } = null;
 
         /// <summary>
-        /// Gets the value of the correlation vector as a string.
+        /// Gets the value of the Correlation Vector as a string.
         /// </summary>
         public string Value
         {

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVector.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVector.cs
@@ -51,7 +51,7 @@ namespace System.Diagnostics
         {
             get
             {
-                return string.Concat(_baseVector, ElementChar, _extension);
+                return string.Concat(_baseVector, ElementChar, _extension.ToString("X"));
             }
         }
 
@@ -76,14 +76,14 @@ namespace System.Diagnostics
                     return Value;
                 }
                 next = snapshot + 1;
-                int size = _baseVector.Length + 1 + (int)Math.Log10(next) + 1;
+                int size = _baseVector.Length + 1 + (int)Math.Log(next, 16) + 1;
                 if (size > CorrelationVector.MaxVectorLength)
                 {
                     // Perform a reset
                     lock (_resetLock)
                     {
                         // Check size again in case another thread did the reset
-                        size = _baseVector.Length + 1 + (int)Math.Log10(next) + 1;
+                        size = _baseVector.Length + 1 + (int)Math.Log(next, 16) + 1;
                         if (size > CorrelationVector.MaxVectorLength)
                         {
                             PreviousValue = Value;
@@ -94,7 +94,7 @@ namespace System.Diagnostics
             }
             while (snapshot != Interlocked.CompareExchange(ref _extension, next, snapshot));
 
-            return string.Concat(_baseVector, ElementChar, next);
+            return string.Concat(_baseVector, ElementChar, next.ToString("X"));
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace System.Diagnostics
 
             // 3 accounts for the "_" before the spin element and the
             // ".0" at the end of the new CorrelationVector
-            int size = correlationVector.Length + 3 + (int)Math.Log10(spinElement) + 1;
+            int size = correlationVector.Length + 3 + (int)Math.Log(spinElement, 16) + 1;
 
             if (size > CorrelationVector.MaxVectorLength)
             {
@@ -170,7 +170,7 @@ namespace System.Diagnostics
 
             return new CorrelationVector()
             {
-                _baseVector = string.Concat(correlationVector, SpinChar, spinElement),
+                _baseVector = string.Concat(correlationVector, SpinChar, spinElement.ToString("X")),
                 _extension = 0
             };
         }
@@ -219,7 +219,11 @@ namespace System.Diagnostics
         {
             string baseVector = GetBaseFromVector(correlationVector);
 
-            return string.Concat(baseVector, ElementChar, ResetChar, GetTimeSortedRandomLong());
+            return string.Concat(
+                baseVector,
+                ElementChar,
+                ResetChar,
+                GetTimeSortedRandomLong().ToString("X"));
         }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVectorResetResult.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/CorrelationVectorResetResult.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Represents a mapping that will be logged after a Correlation Vector has been Reset
+    /// due to its length exceeding the maximum allowed.
+    /// </summary>
+    public class CorrelationVectorResetResult
+    {
+        /// <summary>
+        /// Correlation Vector base prior to the Reset.
+        /// </summary>
+        public string BaseVector { get; set; } = null;
+
+        /// <summary>
+        /// Correlation Vector extension that resulted from the Reset.
+        /// </summary>
+        public string ResetExtension { get; set; } = null;
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/tests/CorrelationVectorTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/CorrelationVectorTests.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public class CorrelationVectorTests
+    {
+        [Fact]
+        public void BasicCorrelationVector()
+        {
+            var correlationVector = new CorrelationVector();
+
+            Assert.NotNull(correlationVector.Value);
+            Assert.False(string.IsNullOrWhiteSpace(correlationVector.Value));
+            Assert.Equal(24, correlationVector.Value.Length);
+            Assert.True(correlationVector.Value.EndsWith(".0"));
+            Assert.Equal(1, correlationVector.Value.Count(c => c == '.'));
+        }
+
+        [Fact]
+        public void IncrementTriggersReset()
+        {
+            var correlationVector = new CorrelationVector();
+
+            string correlationVectorString = correlationVector.Value;
+
+            while (correlationVectorString.Length < 124)
+            {
+                correlationVectorString += ".1";
+            }
+
+            CorrelationVector aboutToOverflow = CorrelationVector.Extend(correlationVectorString);
+
+            Assert.Equal(string.Concat(correlationVectorString, ".0"), aboutToOverflow.Value);
+            int incrementCounter = 0;
+
+            while (aboutToOverflow.Value.Length > 124)
+            {
+                string incrementedValue = aboutToOverflow.Increment();
+                incrementCounter++;
+
+                Assert.Equal(incrementedValue, aboutToOverflow.Value);
+                Assert.False(aboutToOverflow.Value.Length > 127);
+            }
+
+            Assert.StartsWith("#", aboutToOverflow.Value);
+            Assert.EndsWith(string.Concat(".", incrementCounter), aboutToOverflow.Value);
+            Assert.Equal(1, aboutToOverflow.Value.Count(c => c == '.'));
+            Assert.DoesNotContain(
+                correlationVector.Value.Substring(0, correlationVector.Value.IndexOf('.')),
+                aboutToOverflow.Value);
+
+            aboutToOverflow.Increment();
+            incrementCounter++;
+
+            Assert.EndsWith(string.Concat(".", incrementCounter), aboutToOverflow.Value);
+        }
+
+        [Fact]
+        public void ExtendTriggersReset()
+        {
+            var originalCorrelationVector = new CorrelationVector();
+
+            var correlationVector = CorrelationVector.Extend(originalCorrelationVector.Value);
+
+            while (correlationVector.Value.Length > 25)
+            {
+                correlationVector = CorrelationVector.Extend(correlationVector.Value);
+            }
+
+            Assert.StartsWith("#", correlationVector.Value);
+            Assert.EndsWith(".0", correlationVector.Value);
+            Assert.DoesNotContain(
+                originalCorrelationVector.Value.Substring(0, originalCorrelationVector.Value.IndexOf('.')),
+                correlationVector.Value);
+        }
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/tests/CorrelationVectorTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/CorrelationVectorTests.cs
@@ -37,7 +37,7 @@ namespace System.Diagnostics.Tests
             var vector = CorrelationVector.Extend(originalVector);
 
             Assert.Equal(string.Concat(originalVector, ".0"), vector.ToString());
-            
+
             var incrementedVector = vector.Increment();
 
             Assert.Equal(string.Concat(originalVector, ".1"), vector.ToString());
@@ -97,7 +97,7 @@ namespace System.Diagnostics.Tests
             string originalBase = originalValue.Substring(0, originalValue.IndexOf('.'));
 
             var correlationVector = CorrelationVector.Extend(originalValue);
-            
+
             // Validate the properties of a Reset Correlation Vector
             Assert.StartsWith(ResetChar, correlationVector.Value);
             Assert.EndsWith(".0", correlationVector.Value);
@@ -199,7 +199,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(string.Concat(originalValue, ".0"), aboutToOverflow.Value);
             Assert.Equal(127, aboutToOverflow.Value.Length);
 
-            for (int i=1; i<10; i++)
+            for (int i = 1; i < 10; i++)
             {
                 string incrementedValue = aboutToOverflow.Increment();
 
@@ -219,7 +219,7 @@ namespace System.Diagnostics.Tests
 
             // Validate that an additional Increment behaves like normal
             aboutToOverflow.Increment();
-            
+
             Assert.EndsWith(".11", aboutToOverflow.Value);
         }
 
@@ -245,6 +245,38 @@ namespace System.Diagnostics.Tests
             ulong spinElement;
 
             Assert.True(ulong.TryParse(spinElementString, out spinElement));
+        }
+
+        [Fact]
+        public void SpinSortValidation()
+        {
+            var vector = new CorrelationVector();
+            ulong lastSpinValue = 0;
+            int wrappedCounter = 0;
+
+            for (int i = 0; i < 100; i++)
+            {
+                CorrelationVector spunVector = CorrelationVector.Spin(vector.Value);
+                
+                // The cV after a Spin will look like <cvBase>.0_<spinValue>.0, so the spinValue is at index = 2.
+                string spinElement = spunVector.Value.Split('_')[1].Replace(".0", string.Empty);
+
+                ulong spinValue = ulong.Parse(spinElement);
+
+                // Count the number of times the counter wraps.
+                if (spinValue <= lastSpinValue)
+                {
+                    wrappedCounter++;
+                }
+
+                lastSpinValue = spinValue;
+
+                // Wait for 10ms.
+                Task.Delay(10).Wait();
+            }
+
+            // The counter should wrap at most 1 time.
+            Assert.True(wrappedCounter <= 1);
         }
 
         [Fact]

--- a/src/System.Diagnostics.DiagnosticSource/tests/CorrelationVectorTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/CorrelationVectorTests.cs
@@ -29,7 +29,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(BaseLength + 2, correlationVector.Value.Length);
             Assert.True(correlationVector.Value.EndsWith(".0"));
             Assert.Equal(1, correlationVector.Value.Count(c => c == '.'));
-            Assert.Null(correlationVector.PreviousValue);
+            Assert.Null(correlationVector.ResetResult);
         }
 
         [Fact]
@@ -185,7 +185,9 @@ namespace System.Diagnostics.Tests
                     out resetElement));
             Assert.Equal("0", parts[2]);
 
-            Assert.Equal(originalValue, vector.PreviousValue);
+            Assert.NotNull(vector.ResetResult);
+            Assert.Equal(originalValue, vector.ResetResult.BaseVector);
+            Assert.Equal(parts[1].Substring(1), vector.ResetResult.ResetExtension);
         }
 
         [Fact]
@@ -279,8 +281,9 @@ namespace System.Diagnostics.Tests
             aboutToOverflow.Increment();
 
             // Validate the properties of a Reset Correlation Vector
+            // The stored pre-reset BaseVector should not contain the last ".F", so remove it
             ValidateResetCorrelationVector(
-                preResetValue: incrementedValue,
+                preResetValue: incrementedValue.Replace(".F", string.Empty),
                 resetVector: aboutToOverflow,
                 expectedExtension: 16);
 
@@ -386,7 +389,9 @@ namespace System.Diagnostics.Tests
                     out resetElement));
             Assert.Equal(expectedExtension.ToString("X"), parts[2]);
 
-            Assert.Equal(preResetValue, resetVector.PreviousValue);
+            Assert.NotNull(resetVector.ResetResult);
+            Assert.Equal(preResetValue, resetVector.ResetResult.BaseVector);
+            Assert.Equal(parts[1].Substring(1), resetVector.ResetResult.ResetExtension);
         }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -510,112 +510,112 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        ///// <summary>
-        ///// Tests that keywords that define shortcuts work.    
-        ///// </summary>
-        //[Fact]
-        //public void TestShortcutKeywords()
-        //{
-        //    using (var eventSourceListener = new TestDiagnosticSourceEventListener())
-        //    // These are look-alikes for the real ones.  
-        //    using (var aspNetCoreSource = new DiagnosticListener("Microsoft.AspNetCore"))
-        //    using (var entityFrameworkCoreSource = new DiagnosticListener("Microsoft.EntityFrameworkCore"))
-        //    {
-        //        // These are from DiagnosticSourceEventListener.  
-        //        var Messages = (EventKeywords)0x1;
-        //        var Events = (EventKeywords)0x2;
-        //        var AspNetCoreHosting = (EventKeywords)0x1000;
-        //        var EntityFrameworkCoreCommands = (EventKeywords)0x2000;
+        /// <summary>
+        /// Tests that keywords that define shortcuts work.    
+        /// </summary>
+        [Fact]
+        public void TestShortcutKeywords()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            // These are look-alikes for the real ones.  
+            using (var aspNetCoreSource = new DiagnosticListener("Microsoft.AspNetCore"))
+            using (var entityFrameworkCoreSource = new DiagnosticListener("Microsoft.EntityFrameworkCore"))
+            {
+                // These are from DiagnosticSourceEventListener.  
+                var Messages = (EventKeywords)0x1;
+                var Events = (EventKeywords)0x2;
+                var AspNetCoreHosting = (EventKeywords)0x1000;
+                var EntityFrameworkCoreCommands = (EventKeywords)0x2000;
 
-        //        // Turn on listener using just the keywords 
-        //        eventSourceListener.Enable(null, Messages | Events | AspNetCoreHosting | EntityFrameworkCoreCommands);
+                // Turn on listener using just the keywords 
+                eventSourceListener.Enable(null, Messages | Events | AspNetCoreHosting | EntityFrameworkCoreCommands);
 
-        //        Assert.Equal(0, eventSourceListener.EventCount);
+                Assert.Equal(0, eventSourceListener.EventCount);
 
-        //        // Start a ASP.NET Request
-        //        aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.BeginRequest",
-        //            new
-        //            {
-        //                httpContext = new
-        //                {
-        //                    Request = new
-        //                    {
-        //                        Method = "Get",
-        //                        Host = "MyHost",
-        //                        Path = "MyPath",
-        //                        QueryString = "MyQuery"
-        //                    }
-        //                }
-        //            });
-        //        // Check that the morphs work as expected.  
-        //        Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
-        //        Assert.Equal("Activity1Start", eventSourceListener.LastEvent.EventSourceEventName);
-        //        Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
-        //        Assert.Equal("Microsoft.AspNetCore.Hosting.BeginRequest", eventSourceListener.LastEvent.EventName);
-        //        Assert.True(4 <= eventSourceListener.LastEvent.Arguments.Count);
-        //        Debug.WriteLine("Arg Keys = " + string.Join(" ", eventSourceListener.LastEvent.Arguments.Keys));
-        //        Debug.WriteLine("Arg Values = " + string.Join(" ", eventSourceListener.LastEvent.Arguments.Values));
-        //        Assert.Equal("Get", eventSourceListener.LastEvent.Arguments["Method"]);
-        //        Assert.Equal("MyHost", eventSourceListener.LastEvent.Arguments["Host"]);
-        //        Assert.Equal("MyPath", eventSourceListener.LastEvent.Arguments["Path"]);
-        //        Assert.Equal("MyQuery", eventSourceListener.LastEvent.Arguments["QueryString"]);
-        //        eventSourceListener.ResetEventCountAndLastEvent();
+                // Start a ASP.NET Request
+                aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.BeginRequest",
+                    new
+                    {
+                        httpContext = new
+                        {
+                            Request = new
+                            {
+                                Method = "Get",
+                                Host = "MyHost",
+                                Path = "MyPath",
+                                QueryString = "MyQuery"
+                            }
+                        }
+                    });
+                // Check that the morphs work as expected.  
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Activity1Start", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("Microsoft.AspNetCore.Hosting.BeginRequest", eventSourceListener.LastEvent.EventName);
+                Assert.True(4 <= eventSourceListener.LastEvent.Arguments.Count);
+                Debug.WriteLine("Arg Keys = " + string.Join(" ", eventSourceListener.LastEvent.Arguments.Keys));
+                Debug.WriteLine("Arg Values = " + string.Join(" ", eventSourceListener.LastEvent.Arguments.Values));
+                Assert.Equal("Get", eventSourceListener.LastEvent.Arguments["Method"]);
+                Assert.Equal("MyHost", eventSourceListener.LastEvent.Arguments["Host"]);
+                Assert.Equal("MyPath", eventSourceListener.LastEvent.Arguments["Path"]);
+                Assert.Equal("MyQuery", eventSourceListener.LastEvent.Arguments["QueryString"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
 
-        //        // Start a SQL command 
-        //        entityFrameworkCoreSource.Write("Microsoft.EntityFrameworkCore.BeforeExecuteCommand",
-        //            new
-        //            {
-        //                Command = new
-        //                {
-        //                    Connection = new
-        //                    {
-        //                        DataSource = "MyDataSource",
-        //                        Database = "MyDatabase",
-        //                    },
-        //                    CommandText = "MyCommand"
-        //                }
-        //            });
-        //        Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
-        //        Assert.Equal("Activity2Start", eventSourceListener.LastEvent.EventSourceEventName);
-        //        Assert.Equal("Microsoft.EntityFrameworkCore", eventSourceListener.LastEvent.SourceName);
-        //        Assert.Equal("Microsoft.EntityFrameworkCore.BeforeExecuteCommand", eventSourceListener.LastEvent.EventName);
-        //        Assert.True(3 <= eventSourceListener.LastEvent.Arguments.Count);
-        //        Assert.Equal("MyDataSource", eventSourceListener.LastEvent.Arguments["DataSource"]);
-        //        Assert.Equal("MyDatabase", eventSourceListener.LastEvent.Arguments["Database"]);
-        //        Assert.Equal("MyCommand", eventSourceListener.LastEvent.Arguments["CommandText"]);
-        //        eventSourceListener.ResetEventCountAndLastEvent();
+                // Start a SQL command 
+                entityFrameworkCoreSource.Write("Microsoft.EntityFrameworkCore.BeforeExecuteCommand",
+                    new
+                    {
+                        Command = new
+                        {
+                            Connection = new
+                            {
+                                DataSource = "MyDataSource",
+                                Database = "MyDatabase",
+                            },
+                            CommandText = "MyCommand"
+                        }
+                    });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Activity2Start", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("Microsoft.EntityFrameworkCore", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("Microsoft.EntityFrameworkCore.BeforeExecuteCommand", eventSourceListener.LastEvent.EventName);
+                Assert.True(3 <= eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("MyDataSource", eventSourceListener.LastEvent.Arguments["DataSource"]);
+                Assert.Equal("MyDatabase", eventSourceListener.LastEvent.Arguments["Database"]);
+                Assert.Equal("MyCommand", eventSourceListener.LastEvent.Arguments["CommandText"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
 
-        //        // Stop the SQL command 
-        //        entityFrameworkCoreSource.Write("Microsoft.EntityFrameworkCore.AfterExecuteCommand", null);
-        //        Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
-        //        Assert.Equal("Activity2Stop", eventSourceListener.LastEvent.EventSourceEventName);
-        //        Assert.Equal("Microsoft.EntityFrameworkCore", eventSourceListener.LastEvent.SourceName);
-        //        Assert.Equal("Microsoft.EntityFrameworkCore.AfterExecuteCommand", eventSourceListener.LastEvent.EventName);
-        //        eventSourceListener.ResetEventCountAndLastEvent();
+                // Stop the SQL command 
+                entityFrameworkCoreSource.Write("Microsoft.EntityFrameworkCore.AfterExecuteCommand", null);
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Activity2Stop", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("Microsoft.EntityFrameworkCore", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("Microsoft.EntityFrameworkCore.AfterExecuteCommand", eventSourceListener.LastEvent.EventName);
+                eventSourceListener.ResetEventCountAndLastEvent();
 
-        //        // Stop the ASP.NET request.  
-        //        aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.EndRequest", 
-        //            new
-        //            {
-        //                httpContext = new
-        //                {
-        //                    Response = new
-        //                    {
-        //                        StatusCode = "200"
-        //                    },
-        //                    TraceIdentifier = "MyTraceId"
-        //                }
-        //            });
-        //        Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
-        //        Assert.Equal("Activity1Stop", eventSourceListener.LastEvent.EventSourceEventName);
-        //        Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
-        //        Assert.Equal("Microsoft.AspNetCore.Hosting.EndRequest", eventSourceListener.LastEvent.EventName);
-        //        Assert.True(2 <= eventSourceListener.LastEvent.Arguments.Count);
-        //        Assert.Equal("MyTraceId", eventSourceListener.LastEvent.Arguments["TraceIdentifier"]);
-        //        Assert.Equal("200", eventSourceListener.LastEvent.Arguments["StatusCode"]);
-        //        eventSourceListener.ResetEventCountAndLastEvent();
-        //    }
-        //}
+                // Stop the ASP.NET request.  
+                aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.EndRequest",
+                    new
+                    {
+                        httpContext = new
+                        {
+                            Response = new
+                            {
+                                StatusCode = "200"
+                            },
+                            TraceIdentifier = "MyTraceId"
+                        }
+                    });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Activity1Stop", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("Microsoft.AspNetCore.Hosting.EndRequest", eventSourceListener.LastEvent.EventName);
+                Assert.True(2 <= eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("MyTraceId", eventSourceListener.LastEvent.Arguments["TraceIdentifier"]);
+                Assert.Equal("200", eventSourceListener.LastEvent.Arguments["StatusCode"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+            }
+        }
     }
 
     /****************************************************************************/

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -510,112 +510,112 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        /// <summary>
-        /// Tests that keywords that define shortcuts work.    
-        /// </summary>
-        [Fact]
-        public void TestShortcutKeywords()
-        {
-            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
-            // These are look-alikes for the real ones.  
-            using (var aspNetCoreSource = new DiagnosticListener("Microsoft.AspNetCore"))
-            using (var entityFrameworkCoreSource = new DiagnosticListener("Microsoft.EntityFrameworkCore"))
-            {
-                // These are from DiagnosticSourceEventListener.  
-                var Messages = (EventKeywords)0x1;
-                var Events = (EventKeywords)0x2;
-                var AspNetCoreHosting = (EventKeywords)0x1000;
-                var EntityFrameworkCoreCommands = (EventKeywords)0x2000;
+        ///// <summary>
+        ///// Tests that keywords that define shortcuts work.    
+        ///// </summary>
+        //[Fact]
+        //public void TestShortcutKeywords()
+        //{
+        //    using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+        //    // These are look-alikes for the real ones.  
+        //    using (var aspNetCoreSource = new DiagnosticListener("Microsoft.AspNetCore"))
+        //    using (var entityFrameworkCoreSource = new DiagnosticListener("Microsoft.EntityFrameworkCore"))
+        //    {
+        //        // These are from DiagnosticSourceEventListener.  
+        //        var Messages = (EventKeywords)0x1;
+        //        var Events = (EventKeywords)0x2;
+        //        var AspNetCoreHosting = (EventKeywords)0x1000;
+        //        var EntityFrameworkCoreCommands = (EventKeywords)0x2000;
 
-                // Turn on listener using just the keywords 
-                eventSourceListener.Enable(null, Messages | Events | AspNetCoreHosting | EntityFrameworkCoreCommands);
+        //        // Turn on listener using just the keywords 
+        //        eventSourceListener.Enable(null, Messages | Events | AspNetCoreHosting | EntityFrameworkCoreCommands);
 
-                Assert.Equal(0, eventSourceListener.EventCount);
+        //        Assert.Equal(0, eventSourceListener.EventCount);
 
-                // Start a ASP.NET Request
-                aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.BeginRequest",
-                    new
-                    {
-                        httpContext = new
-                        {
-                            Request = new
-                            {
-                                Method = "Get",
-                                Host = "MyHost",
-                                Path = "MyPath",
-                                QueryString = "MyQuery"
-                            }
-                        }
-                    });
-                // Check that the morphs work as expected.  
-                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
-                Assert.Equal("Activity1Start", eventSourceListener.LastEvent.EventSourceEventName);
-                Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
-                Assert.Equal("Microsoft.AspNetCore.Hosting.BeginRequest", eventSourceListener.LastEvent.EventName);
-                Assert.True(4 <= eventSourceListener.LastEvent.Arguments.Count);
-                Debug.WriteLine("Arg Keys = " + string.Join(" ", eventSourceListener.LastEvent.Arguments.Keys));
-                Debug.WriteLine("Arg Values = " + string.Join(" ", eventSourceListener.LastEvent.Arguments.Values));
-                Assert.Equal("Get", eventSourceListener.LastEvent.Arguments["Method"]);
-                Assert.Equal("MyHost", eventSourceListener.LastEvent.Arguments["Host"]);
-                Assert.Equal("MyPath", eventSourceListener.LastEvent.Arguments["Path"]);
-                Assert.Equal("MyQuery", eventSourceListener.LastEvent.Arguments["QueryString"]);
-                eventSourceListener.ResetEventCountAndLastEvent();
+        //        // Start a ASP.NET Request
+        //        aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.BeginRequest",
+        //            new
+        //            {
+        //                httpContext = new
+        //                {
+        //                    Request = new
+        //                    {
+        //                        Method = "Get",
+        //                        Host = "MyHost",
+        //                        Path = "MyPath",
+        //                        QueryString = "MyQuery"
+        //                    }
+        //                }
+        //            });
+        //        // Check that the morphs work as expected.  
+        //        Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+        //        Assert.Equal("Activity1Start", eventSourceListener.LastEvent.EventSourceEventName);
+        //        Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
+        //        Assert.Equal("Microsoft.AspNetCore.Hosting.BeginRequest", eventSourceListener.LastEvent.EventName);
+        //        Assert.True(4 <= eventSourceListener.LastEvent.Arguments.Count);
+        //        Debug.WriteLine("Arg Keys = " + string.Join(" ", eventSourceListener.LastEvent.Arguments.Keys));
+        //        Debug.WriteLine("Arg Values = " + string.Join(" ", eventSourceListener.LastEvent.Arguments.Values));
+        //        Assert.Equal("Get", eventSourceListener.LastEvent.Arguments["Method"]);
+        //        Assert.Equal("MyHost", eventSourceListener.LastEvent.Arguments["Host"]);
+        //        Assert.Equal("MyPath", eventSourceListener.LastEvent.Arguments["Path"]);
+        //        Assert.Equal("MyQuery", eventSourceListener.LastEvent.Arguments["QueryString"]);
+        //        eventSourceListener.ResetEventCountAndLastEvent();
 
-                // Start a SQL command 
-                entityFrameworkCoreSource.Write("Microsoft.EntityFrameworkCore.BeforeExecuteCommand",
-                    new
-                    {
-                        Command = new
-                        {
-                            Connection = new
-                            {
-                                DataSource = "MyDataSource",
-                                Database = "MyDatabase",
-                            },
-                            CommandText = "MyCommand"
-                        }
-                    });
-                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
-                Assert.Equal("Activity2Start", eventSourceListener.LastEvent.EventSourceEventName);
-                Assert.Equal("Microsoft.EntityFrameworkCore", eventSourceListener.LastEvent.SourceName);
-                Assert.Equal("Microsoft.EntityFrameworkCore.BeforeExecuteCommand", eventSourceListener.LastEvent.EventName);
-                Assert.True(3 <= eventSourceListener.LastEvent.Arguments.Count);
-                Assert.Equal("MyDataSource", eventSourceListener.LastEvent.Arguments["DataSource"]);
-                Assert.Equal("MyDatabase", eventSourceListener.LastEvent.Arguments["Database"]);
-                Assert.Equal("MyCommand", eventSourceListener.LastEvent.Arguments["CommandText"]);
-                eventSourceListener.ResetEventCountAndLastEvent();
+        //        // Start a SQL command 
+        //        entityFrameworkCoreSource.Write("Microsoft.EntityFrameworkCore.BeforeExecuteCommand",
+        //            new
+        //            {
+        //                Command = new
+        //                {
+        //                    Connection = new
+        //                    {
+        //                        DataSource = "MyDataSource",
+        //                        Database = "MyDatabase",
+        //                    },
+        //                    CommandText = "MyCommand"
+        //                }
+        //            });
+        //        Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+        //        Assert.Equal("Activity2Start", eventSourceListener.LastEvent.EventSourceEventName);
+        //        Assert.Equal("Microsoft.EntityFrameworkCore", eventSourceListener.LastEvent.SourceName);
+        //        Assert.Equal("Microsoft.EntityFrameworkCore.BeforeExecuteCommand", eventSourceListener.LastEvent.EventName);
+        //        Assert.True(3 <= eventSourceListener.LastEvent.Arguments.Count);
+        //        Assert.Equal("MyDataSource", eventSourceListener.LastEvent.Arguments["DataSource"]);
+        //        Assert.Equal("MyDatabase", eventSourceListener.LastEvent.Arguments["Database"]);
+        //        Assert.Equal("MyCommand", eventSourceListener.LastEvent.Arguments["CommandText"]);
+        //        eventSourceListener.ResetEventCountAndLastEvent();
 
-                // Stop the SQL command 
-                entityFrameworkCoreSource.Write("Microsoft.EntityFrameworkCore.AfterExecuteCommand", null);
-                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
-                Assert.Equal("Activity2Stop", eventSourceListener.LastEvent.EventSourceEventName);
-                Assert.Equal("Microsoft.EntityFrameworkCore", eventSourceListener.LastEvent.SourceName);
-                Assert.Equal("Microsoft.EntityFrameworkCore.AfterExecuteCommand", eventSourceListener.LastEvent.EventName);
-                eventSourceListener.ResetEventCountAndLastEvent();
+        //        // Stop the SQL command 
+        //        entityFrameworkCoreSource.Write("Microsoft.EntityFrameworkCore.AfterExecuteCommand", null);
+        //        Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+        //        Assert.Equal("Activity2Stop", eventSourceListener.LastEvent.EventSourceEventName);
+        //        Assert.Equal("Microsoft.EntityFrameworkCore", eventSourceListener.LastEvent.SourceName);
+        //        Assert.Equal("Microsoft.EntityFrameworkCore.AfterExecuteCommand", eventSourceListener.LastEvent.EventName);
+        //        eventSourceListener.ResetEventCountAndLastEvent();
 
-                // Stop the ASP.NET request.  
-                aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.EndRequest", 
-                    new
-                    {
-                        httpContext = new
-                        {
-                            Response = new
-                            {
-                                StatusCode = "200"
-                            },
-                            TraceIdentifier = "MyTraceId"
-                        }
-                    });
-                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
-                Assert.Equal("Activity1Stop", eventSourceListener.LastEvent.EventSourceEventName);
-                Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
-                Assert.Equal("Microsoft.AspNetCore.Hosting.EndRequest", eventSourceListener.LastEvent.EventName);
-                Assert.True(2 <= eventSourceListener.LastEvent.Arguments.Count);
-                Assert.Equal("MyTraceId", eventSourceListener.LastEvent.Arguments["TraceIdentifier"]);
-                Assert.Equal("200", eventSourceListener.LastEvent.Arguments["StatusCode"]);
-                eventSourceListener.ResetEventCountAndLastEvent();
-            }
-        }
+        //        // Stop the ASP.NET request.  
+        //        aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.EndRequest", 
+        //            new
+        //            {
+        //                httpContext = new
+        //                {
+        //                    Response = new
+        //                    {
+        //                        StatusCode = "200"
+        //                    },
+        //                    TraceIdentifier = "MyTraceId"
+        //                }
+        //            });
+        //        Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+        //        Assert.Equal("Activity1Stop", eventSourceListener.LastEvent.EventSourceEventName);
+        //        Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
+        //        Assert.Equal("Microsoft.AspNetCore.Hosting.EndRequest", eventSourceListener.LastEvent.EventName);
+        //        Assert.True(2 <= eventSourceListener.LastEvent.Arguments.Count);
+        //        Assert.Equal("MyTraceId", eventSourceListener.LastEvent.Arguments["TraceIdentifier"]);
+        //        Assert.Equal("200", eventSourceListener.LastEvent.Arguments["StatusCode"]);
+        //        eventSourceListener.ResetEventCountAndLastEvent();
+        //    }
+        //}
     }
 
     /****************************************************************************/

--- a/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CorrelationVectorTests.cs" />
     <Compile Include="DiagnosticSourceTests.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetGroup)' != 'netstandard1.1'">


### PR DESCRIPTION
These changes are still a work in progress. Notable things left to-do...

- Update summary tag commenting. Some has been carried over from SLL implementation, other is 'TBD'. All of it needs a proper scrubbing.
- Apply consistent styling / formatting per corefx guidelines. I need to read through these and get a better idea of what I should focus on.

My current plan is to leave the integration with the Activity and Http Handler Diagnostic Listener (which sets the Request-Id header) to a future pull request. Sole purpose of this pull request is to solicit early feedback, as we'll need to complete the API design / approval process first.